### PR TITLE
Fix redacting logger dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,7 @@ gem "faraday", "~> 2.7"
 gem "faraday-retry", "~> 2.2"
 gem "git", "~> 1.18"
 gem "octokit", "~> 8.0"
-
-source "https://rubygems.pkg.github.com/github" do
-  gem "redacting-logger", "~> 1.0"
-end
+gem "redacting-logger", "~> 1.0"
 
 group :development do
   gem "irb", "~> 1.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
     rchardet (1.8.0)
     rdoc (6.6.0)
       psych (>= 4.0.0)
+    redacting-logger (1.0.0)
+      logger (~> 1.6)
     regexp_parser (2.8.2)
     reline (0.4.0)
       io-console (~> 0.5)
@@ -127,12 +129,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
 
-GEM
-  remote: https://rubygems.pkg.github.com/github/
-  specs:
-    redacting-logger (1.0.0)
-      logger (~> 1.6)
-
 PLATFORMS
   arm64-darwin-21
   darwin
@@ -146,7 +142,7 @@ DEPENDENCIES
   git (~> 1.18)
   irb (~> 1.9)
   octokit (~> 8.0)
-  redacting-logger (~> 1.0)!
+  redacting-logger (~> 1.0)
   rspec (~> 3.12)
   rubocop (~> 1.56)
   rubocop-github (~> 0.20)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Octokitted
   module Version
-    VERSION = "1.2.0"
+    VERSION = "1.2.1"
   end
 end


### PR DESCRIPTION
This Gem's latest version cannot be installed due to the broken dependency pull on the `redacting-logger`